### PR TITLE
trailing whitespaces and long lines breaks typical pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      # https://pre-commit.com/hooks.html
+      - id: check-added-large-files
+      - id: check-executables-have-shebangs
+      - id: check-symlinks
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.35.0
+    hooks:
+      - id: markdownlint

--- a/README.md
+++ b/README.md
@@ -1,17 +1,23 @@
 <!--
-SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR), Forschungszentrum Jülich, Helmholtz-Zentrum Dresden-Rossendorf
+SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR), \
+                             Forschungszentrum Jülich, \
+                             Helmholtz-Zentrum Dresden-Rossendorf
 
 SPDX-License-Identifier: CC0-1.0
 -->
 
 # HERMES continuous integration templates
 
-This repository contains templates for continuous integration systems that can be used to publish software automatically.
+This repository contains templates for continuous integration systems
+that can be used to publish software automatically.
 
 ## License
 
-- Continuous integration templates are licensed under [CC0-1.0](https://github.com/hermes-hmc/ci-templates/blob/main/LICENSES/CC0-1.0.txt).
+- Continuous integration templates are licensed under
+  [CC0-1.0](https://github.com/hermes-hmc/ci-templates/blob/main/LICENSES/CC0-1.0.txt).
 
 Please see the [LICENSES/](LICENSES/) directory and the headers in files for details.
 
-Copyright (c) 2023 German Aerospace Center (DLR), Forschungszentrum Jülich, Helmholtz-Zentrum Dresden-Rossendorf
+Copyright (c) 2023 German Aerospace Center (DLR),
+                   Forschungszentrum Jülich,
+                   Helmholtz-Zentrum Dresden-Rossendorf

--- a/README.md
+++ b/README.md
@@ -15,4 +15,3 @@ This repository contains templates for continuous integration systems that can b
 Please see the [LICENSES/](LICENSES/) directory and the headers in files for details.
 
 Copyright (c) 2023 German Aerospace Center (DLR), Forschungszentrum Jülich, Helmholtz-Zentrum Dresden-Rossendorf
-

--- a/TEMPLATE_hermes_github_to_zenodo.yml
+++ b/TEMPLATE_hermes_github_to_zenodo.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     # This condition becomes much easier when we only react to push events on the release branch.
     # We still need to exclude the merge commit push of the post processing PR
-    
+
     # ADAPT
     # Depending on the event you react to in the 'on:' section above, you will need to adapt this
     # to react on the specific events.
@@ -53,18 +53,18 @@ jobs:
       - run: hermes process
       - run: hermes curate
 
-      - run: |      
-          # Cache current branch for PR close job 
+      - run: |
+          # Cache current branch for PR close job
           git branch --show-current > .hermes/curate/target_branch
-          
+
           # Shorten the SHA for the PR title
           SHORT_SHA=$(echo "$GITHUB_SHA" | cut -c -8)
           echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
-          
+
           # Create a curation branch
           git branch -c "hermes/curate-$SHORT_SHA"
           git push origin "hermes/curate-$SHORT_SHA"
-          
+
           # Explicitly add to-be-curated metadata (which is ignored via .gitignore!)
           git add -f .hermes/curate
       - uses: peter-evans/create-pull-request@v5
@@ -107,14 +107,14 @@ jobs:
       # 3. Check if you want to run with '--initial', as this may potentially create a completely new record (collection),
       #    rather than a new version of the same collection!
       - run: hermes deposit --initial --auth-token ${{ secrets.ZENODO_SANDBOX }} --file showcase.zip --file README.md
-      
+
       # ADAPT
       # Remove this command if you don't want to do any postprocessing
       - run: hermes postprocess
 
       # ADAPT
       # If you don't want to run postprocessing, remove this complete section (next '-run' and 'uses: peter-evans/...' bullets).
-      # 
+      #
       # Note 1: We change the base branch here for the PR. This flow runs so far within the "curated-metadata-*" branch,
       #         but now we want to add the changes done by deposit and post processing to the branch that was initially
       #         meant to be published using HERMES.
@@ -137,7 +137,7 @@ jobs:
             git push origin --delete "$BRANCH"
           done
       # TODO: if: failure() --- delete the curation branches when the deposition failed
-          
+
 
   hermes-cleanup:
     name: Cleanup aborted curation branches

--- a/gitlab/hermes-ci.yml
+++ b/gitlab/hermes-ci.yml
@@ -119,7 +119,7 @@
         fi
       fi
       echo $MR_POST_BRANCH > .hermes/curate/target_branch
-    
+
     # Create target branch for curation merge
     - git branch "$MR_TARGET_BRANCH" "$MR_BASE_REF"
     - git push origin "$MR_TARGET_BRANCH"
@@ -140,7 +140,7 @@
     MR_COMMIT_MESSAGE: "[hermes] Add post-processing results"
     MR_TITLE: Review hermes post-processing results
     MR_DESCRIPTION: >-
-      This is an automated pull request created by HERMES post-processing. 
+      This is an automated pull request created by HERMES post-processing.
       Please carefully review the changes and finally merge them into your
   rules:
     - if: $CI_PIPELINE_SOURCE != "push" || $CI_COMMIT_BRANCH !~ /^hermes\/curate-[0-9a-f]{8}/
@@ -150,7 +150,7 @@
   script:
     # Restore target branch
     - MR_TARGET_BRANCH="$(cat .hermes/curate/target_branch)"
-    
+
     # Invoke callback to create $HERMES_ARCHIVE_NAME and publish
     - *hermes_create_deposition
     - hermes deposit --initial --auth-token $ZENODO_TOKEN --file $HERMES_ARCHIVE --file README.md


### PR DESCRIPTION
cf. https://github.com/hermes-hmc/ci-templates/issues/5

This merge request provides running pre-commit as github action to ensure typical coding style is followed.

This ensures that user of the templates do not get errors in their ci pipelines.

Further the already existing files are adapted to this common coding style.